### PR TITLE
Stop line fix

### DIFF
--- a/ros/src/tl_detector/sim_traffic_light_config.yaml
+++ b/ros/src/tl_detector/sim_traffic_light_config.yaml
@@ -11,3 +11,4 @@ stop_line_positions:
     - [161.76, 2303.82]
     - [351.84, 1574.65]
 is_site: False
+use_classifier: True

--- a/ros/src/tl_detector/site_traffic_light_config.yaml
+++ b/ros/src/tl_detector/site_traffic_light_config.yaml
@@ -6,3 +6,4 @@ camera_info:
 stop_line_positions:
     - [8.0, 16.2]
 is_site: True
+use_classifier: True

--- a/ros/src/tl_detector/tl_detector.py
+++ b/ros/src/tl_detector/tl_detector.py
@@ -10,6 +10,7 @@ from light_classification.tl_classifier import TLClassifier
 import tf
 import cv2
 import yaml
+from scipy.spatial import KDTree
 
 STATE_COUNT_THRESHOLD = 3
 
@@ -19,6 +20,8 @@ class TLDetector(object):
 
         self.pose = None
         self.waypoints = None
+        self.waypoints_2d = None
+        self.waypoint_tree = None
         self.camera_image = None
         self.lights = []
 
@@ -56,6 +59,9 @@ class TLDetector(object):
 
     def waypoints_cb(self, waypoints):
         self.waypoints = waypoints
+        if not self.waypoints_2d:
+            self.waypoints_2d = [[wp.pose.pose.position.x, wp.pose.pose.position.y] for wp in waypoints.waypoints]
+            self.waypoint_tree = KDTree(self.waypoints_2d)
 
     def traffic_cb(self, msg):
         self.lights = msg.lights
@@ -90,7 +96,7 @@ class TLDetector(object):
             self.upcoming_red_light_pub.publish(Int32(self.last_wp))
         self.state_count += 1
 
-    def get_closest_waypoint(self, pose):
+    def get_closest_waypoint(self, x, y):
         """Identifies the closest path waypoint to the given position
             https://en.wikipedia.org/wiki/Closest_pair_of_points_problem
         Args:
@@ -100,8 +106,8 @@ class TLDetector(object):
             int: index of the closest waypoint in self.waypoints
 
         """
-        #TODO implement
-        return 0
+        closest_idx = self.waypoint_tree.query([x, y], 1)[1]
+        return closest_idx
 
     def get_light_state(self, light):
         """Determines the current color of the traffic light
@@ -113,14 +119,15 @@ class TLDetector(object):
             int: ID of traffic light color (specified in styx_msgs/TrafficLight)
 
         """
-        if(not self.has_image):
-            self.prev_light_loc = None
-            return False
-
-        cv_image = self.bridge.imgmsg_to_cv2(self.camera_image, "bgr8")
-
+        return light.state
+        #if(not self.has_image):
+        #   self.prev_light_loc = None
+        #   return False
+        #
+        #cv_image = self.bridge.imgmsg_to_cv2(self.camera_image, "bgr8")
+        #
         #Get classification
-        return self.light_classifier.get_classification(cv_image)
+        #return self.light_classifier.get_classification(cv_image)
 
     def process_traffic_lights(self):
         """Finds closest visible traffic light, if one exists, and determines its
@@ -136,14 +143,25 @@ class TLDetector(object):
         # List of positions that correspond to the line to stop in front of for a given intersection
         stop_line_positions = self.config['stop_line_positions']
         if(self.pose):
-            car_position = self.get_closest_waypoint(self.pose.pose)
+            car_position = self.get_closest_waypoint(self.pose.pose.position.x, self.pose.pose.position.y)
 
-        #TODO find the closest visible traffic light (if one exists)
+        # find the closest visible traffic light (if one exists)
+        diff = len(self.waypoints.waypoints)
+        for i, temp_light in enumerate(self.lights):
+            # Get the stop line index 
+            line = stop_line_positions[i]
+            line_position = self.get_closest_waypoint(line[0], line[1])
+            # Find closest stop line waypoint index
+            d = line_position - car_position
+            if d > 0 and d < diff:
+                diff = d
+                light = temp_light
+                light_wp = line_position 
 
         if light:
             state = self.get_light_state(light)
             return light_wp, state
-        self.waypoints = None
+
         return -1, TrafficLight.UNKNOWN
 
 if __name__ == '__main__':

--- a/ros/src/tl_detector/tl_detector.py
+++ b/ros/src/tl_detector/tl_detector.py
@@ -2,6 +2,7 @@
 import os
 import glob
 import rospy
+import numpy as np
 from std_msgs.msg import Int32
 from geometry_msgs.msg import PoseStamped, Pose
 from styx_msgs.msg import TrafficLightArray, TrafficLight
@@ -48,8 +49,18 @@ class TLDetector(object):
         self.upcoming_red_light_pub = rospy.Publisher('/traffic_waypoint', Int32, queue_size=1)
 
         self.bridge = CvBridge()
-        frozen_model_file = self.get_model_path()
-        self.light_classifier = TLClassifier(frozen_model_file)
+
+        # Create a Traffic light classifier if configured
+        if self.config['use_classifier']:
+            frozen_model_file = self.get_model_path()
+            self.light_classifier = TLClassifier(frozen_model_file)
+            # First image classification takes longer, so we classify
+            # a dummy image to speed up actual classification later
+            width = self.config['camera_info']['image_width']
+            height = self.config['camera_info']['image_height']
+            dummy_image = np.zeros(shape=(height, width, 3))
+            self.light_classifier.get_classification(dummy_image)
+
         self.listener = tf.TransformListener()
 
         self.state = TrafficLight.UNKNOWN
@@ -161,6 +172,9 @@ class TLDetector(object):
             int: ID of traffic light color (specified in styx_msgs/TrafficLight)
 
         """
+        if (not self.config['use_classifier']):
+           return light.state
+
         if (not self.has_image):
            self.prev_light_loc = None
            return TrafficLight.UNKNOWN
@@ -168,10 +182,7 @@ class TLDetector(object):
         cv_image = self.bridge.imgmsg_to_cv2(self.camera_image, "rgb8")
 
         # Get classification
-        if self.config['use_classifier']:
-            return self.light_classifier.get_classification(cv_image)
-        else:
-            return light.state
+        return self.light_classifier.get_classification(cv_image)
 
     def process_traffic_lights(self):
         """Finds closest visible traffic light, if one exists, and determines its

--- a/ros/src/twist_controller/dbw_node.py
+++ b/ros/src/twist_controller/dbw_node.py
@@ -54,9 +54,27 @@ class DBWNode(object):
                                          BrakeCmd, queue_size=1)
 
         # TODO: Create `Controller` object
-        # self.controller = Controller(<Arguments you wish to provide>)
+        self.controller = Controller(vehicle_mass=vehicle_mass,
+                                     fuel_capacity=fuel_capacity,
+                                     brake_deadband=brake_deadband,
+                                     decel_limit=decel_limit,
+                                     accel_limit=accel_limit,
+                                     wheel_radius=wheel_radius,
+                                     wheel_base=wheel_base,
+                                     steer_ratio=steer_ratio,
+                                     max_lat_accel=max_lat_accel,
+                                     max_steer_angle=max_steer_angle)
 
         # TODO: Subscribe to all the topics you need to
+        rospy.Subscriber('/vehicle/dbw_enabled', Bool, self.dbw_enabled_cb)
+        rospy.Subscriber('/twist_cmd', TwistStamped, self.twist_cb)
+        rospy.Subscriber('/current_velocity', TwistStamped, self.velocity_cb)
+
+        self.current_vel = None
+        self.dbw_enabled = None
+        self.linear_vel = None
+        self.angular_vel = None
+        self.throttle = self.steering = self.brake = 0
 
         self.loop()
 
@@ -65,14 +83,24 @@ class DBWNode(object):
         while not rospy.is_shutdown():
             # TODO: Get predicted throttle, brake, and steering using `twist_controller`
             # You should only publish the control commands if dbw is enabled
-            # throttle, brake, steering = self.controller.control(<proposed linear velocity>,
-            #                                                     <proposed angular velocity>,
-            #                                                     <current linear velocity>,
-            #                                                     <dbw status>,
-            #                                                     <any other argument you need>)
-            # if <dbw is enabled>:
-            #   self.publish(throttle, brake, steer)
+            if not None in (self.current_vel, self.linear_vel, self.angular_vel):
+                self.throttle, self.brake, self.steering = \
+                        self.controller.control(self.current_vel, self.dbw_enabled,
+                                                self.linear_vel, self.angular_vel)
+
+            if self.dbw_enabled:
+                self.publish(self.throttle, self.brake, self.steering)
             rate.sleep()
+
+    def dbw_enabled_cb(self, msg):
+        self.dbw_enabled = msg
+
+    def twist_cb(self, msg):
+        self.linear_vel = msg.twist.linear.x
+        self.angular_vel = msg.twist.angular.z
+
+    def velocity_cb(self, msg):
+        self.current_vel = msg.twist.linear.x
 
     def publish(self, throttle, brake, steer):
         tcmd = ThrottleCmd()

--- a/ros/src/twist_controller/twist_controller.py
+++ b/ros/src/twist_controller/twist_controller.py
@@ -11,7 +11,6 @@ class Controller(object):
     def __init__(self, vehicle_mass, fuel_capacity, brake_deadband, decel_limit,
                        accel_limit, wheel_radius, wheel_base, steer_ratio,
                        max_lat_accel, max_steer_angle):
-        # TODO: Implement
         self.yaw_controller = YawController(wheel_base, steer_ratio, 0.1, max_lat_accel, max_steer_angle)
 
         kp = 0.3
@@ -35,7 +34,6 @@ class Controller(object):
         self.last_time = rospy.get_time()
 
     def control(self, current_vel, dbw_enabled, linear_vel, angular_vel):
-        # TODO: Change the arg, kwarg list to suit your needs
         # Return throttle, brake, steer
 
         if not dbw_enabled:

--- a/ros/src/twist_controller/twist_controller.py
+++ b/ros/src/twist_controller/twist_controller.py
@@ -1,14 +1,69 @@
+import rospy
+from pid import PID
+from lowpass import LowPassFilter
+from yaw_controller import YawController
 
 GAS_DENSITY = 2.858
 ONE_MPH = 0.44704
 
 
 class Controller(object):
-    def __init__(self, *args, **kwargs):
+    def __init__(self, vehicle_mass, fuel_capacity, brake_deadband, decel_limit,
+                       accel_limit, wheel_radius, wheel_base, steer_ratio,
+                       max_lat_accel, max_steer_angle):
         # TODO: Implement
-        pass
+        self.yaw_controller = YawController(wheel_base, steer_ratio, 0.1, max_lat_accel, max_steer_angle)
 
-    def control(self, *args, **kwargs):
+        kp = 0.3
+        ki = 0.1
+        kd = 0.
+        mn = 0.  # Min throttle
+        mx = 0.2 # Max throttle
+        self.throttle_controller = PID(kp, ki, kd, mn, mx)
+
+        tau = 0.5 # 1/(2pi*tau) = cutoff frequency
+        ts = 0.02 # Sample time
+        self.vel_lpf = LowPassFilter(tau, ts)
+    
+        self.vehicle_mass = vehicle_mass
+        self.fuel_capacity = fuel_capacity
+        self.brake_deadband = brake_deadband
+        self.decel_limit = decel_limit
+        self.accel_limit = accel_limit
+        self.wheel_radius = wheel_radius
+
+        self.last_time = rospy.get_time()
+
+    def control(self, current_vel, dbw_enabled, linear_vel, angular_vel):
         # TODO: Change the arg, kwarg list to suit your needs
         # Return throttle, brake, steer
-        return 1., 0., 0.
+
+        if not dbw_enabled:
+            self.throttle_controller.reset()
+            return 0., 0., 0.
+
+        current_vel = self.vel_lpf.filt(current_vel)
+
+        steering = self.yaw_controller.get_steering(linear_vel, angular_vel, current_vel)
+
+        vel_error = linear_vel - current_vel
+        self.last_vel = current_vel
+
+        current_time = rospy.get_time()
+        sample_time = current_time - self.last_time
+        self.last_time = current_time
+
+        throttle = self.throttle_controller.step(vel_error, sample_time)
+        brake = 0
+
+        # if car is trying to stop, at traffic light stop line, hold the car with brake
+        if linear_vel == 0 and current_vel < 0.1:
+            throttle = 0
+            brake = 700
+
+        elif throttle < .1 and vel_error < 0:
+            throttle = 0
+            decel = max(vel_error, self.decel_limit)
+            brake = abs(decel)*self.vehicle_mass*self.wheel_radius # Torque N*m
+
+        return throttle, brake, steering

--- a/ros/src/waypoint_updater/waypoint_updater.py
+++ b/ros/src/waypoint_updater/waypoint_updater.py
@@ -24,7 +24,7 @@ as well as to verify your TL classifier.
 TODO (for Yousuf and Aaron): Stopline location for each traffic light.
 '''
 
-LOOKAHEAD_WPS = 200 # Number of waypoints we will publish. You can change this number
+LOOKAHEAD_WPS = 30 # Number of waypoints we will publish. You can change this number
 MAX_DECEL = 0.5 # Maximum deceleration of waypoints
 
 class WaypointUpdater(object):
@@ -50,7 +50,7 @@ class WaypointUpdater(object):
         self.loop()
 
     def loop(self):
-        rate = rospy.Rate(50)
+        rate = rospy.Rate(15)
         while not rospy.is_shutdown():
             if self.pose and self.base_lane:
                 # Get the closest waypoint
@@ -101,14 +101,15 @@ class WaypointUpdater(object):
 
     def decelerate_waypoints(self, waypoints, start_idx):
         new_waypoints = []
+        #stop_idx = max(self.stopline_wp_idx - start_idx - 2, 0) # -2 to accomodate car front to be behind stop line
+        stop_idx = max(self.stopline_wp_idx - start_idx, 0)
         for i, wp in enumerate(waypoints):
             p = Waypoint()
             p.pose = wp.pose
-            stop_idx = max(self.stopline_wp_idx - start_idx - 2, 0) # -2 to accomodate car front to be behind stop line
             dist = self.distance(waypoints, i, stop_idx)
             vel = math.sqrt(2 * MAX_DECEL * dist) # u^2 = v^2 - 2*a*d, v = 0, a < 0
-            if vel < 1:
-                vel = 0
+            #if vel < 1.0:
+            #   vel = 0
 
             p.twist.twist.linear.x = min(vel, self.get_waypoint_velocity(p))
             new_waypoints.append(p)

--- a/ros/src/waypoint_updater/waypoint_updater.py
+++ b/ros/src/waypoint_updater/waypoint_updater.py
@@ -24,8 +24,8 @@ as well as to verify your TL classifier.
 TODO (for Yousuf and Aaron): Stopline location for each traffic light.
 '''
 
-LOOKAHEAD_WPS = 100 # Number of waypoints we will publish. You can change this number
-STOP_DECEL_WPS = 30 # Number of waypoints to start decelerating for stopline
+LOOKAHEAD_WPS = 200 # Number of waypoints we will publish. You can change this number
+STOP_DECEL_WPS = 25 # Number of waypoints to start decelerating for stopline
 MAX_DECEL = 0.1 # Maximum deceleration of waypoints
 
 class WaypointUpdater(object):

--- a/ros/src/waypoint_updater/waypoint_updater.py
+++ b/ros/src/waypoint_updater/waypoint_updater.py
@@ -36,12 +36,8 @@ class WaypointUpdater(object):
         rospy.Subscriber('/base_waypoints', Lane, self.waypoints_cb)
         rospy.Subscriber('/traffic_waypoint', Int32, self.traffic_cb)
 
-        # TODO: Add a subscriber for /traffic_waypoint and /obstacle_waypoint below
-
-
         self.final_waypoints_pub = rospy.Publisher('final_waypoints', Lane, queue_size=1)
 
-        # TODO: Add other member variables you need below
         self.pose = None
         self.base_lane = None
         self.waypoints_2d = None
@@ -115,18 +111,15 @@ class WaypointUpdater(object):
             
 
     def pose_cb(self, msg):
-        # TODO: Implement
         self.pose = msg
 
     def waypoints_cb(self, waypoints):
-        # TODO: Implement
         self.base_lane = waypoints
         if not self.waypoints_2d:
             self.waypoints_2d = [[wp.pose.pose.position.x, wp.pose.pose.position.y] for wp in waypoints.waypoints]
             self.waypoint_tree = KDTree(self.waypoints_2d)
 
     def traffic_cb(self, msg):
-        # TODO: Callback for /traffic_waypoint message. Implement
         self.stopline_wp_idx = msg.data
 
     def obstacle_cb(self, msg):

--- a/ros/src/waypoint_updater/waypoint_updater.py
+++ b/ros/src/waypoint_updater/waypoint_updater.py
@@ -96,7 +96,7 @@ class WaypointUpdater(object):
         return lane
 
     def decelerate_waypoints(self, waypoints, start_idx):
-        stop_idx = max(self.stopline_wp_idx - start_idx - 2, 0) # -2 to accomodate car front to be behind stop line
+        stop_idx = max(self.stopline_wp_idx - start_idx - 4, 0) # -4 to accomodate car front to be behind stop line
         decel_idx = max(stop_idx - STOP_DECEL_WPS, 0)
         new_waypoints = waypoints[:decel_idx]
         for i in range(decel_idx, len(waypoints)):

--- a/ros/src/waypoint_updater/waypoint_updater.py
+++ b/ros/src/waypoint_updater/waypoint_updater.py
@@ -3,6 +3,7 @@
 import numpy as np
 import rospy
 from geometry_msgs.msg import PoseStamped
+from std_msgs.msg import Int32
 from styx_msgs.msg import Lane, Waypoint
 from scipy.spatial import KDTree
 
@@ -24,7 +25,7 @@ TODO (for Yousuf and Aaron): Stopline location for each traffic light.
 '''
 
 LOOKAHEAD_WPS = 200 # Number of waypoints we will publish. You can change this number
-
+MAX_DECEL = 0.5 # Maximum deceleration of waypoints
 
 class WaypointUpdater(object):
     def __init__(self):
@@ -32,6 +33,7 @@ class WaypointUpdater(object):
 
         rospy.Subscriber('/current_pose', PoseStamped, self.pose_cb)
         rospy.Subscriber('/base_waypoints', Lane, self.waypoints_cb)
+        rospy.Subscriber('/traffic_waypoint', Int32, self.traffic_cb)
 
         # TODO: Add a subscriber for /traffic_waypoint and /obstacle_waypoint below
 
@@ -40,20 +42,21 @@ class WaypointUpdater(object):
 
         # TODO: Add other member variables you need below
         self.pose = None
-        self.base_waypoints = None
+        self.base_lane = None
         self.waypoints_2d = None
         self.waypoint_tree = None
+        self.stopline_wp_idx = -1
 
         self.loop()
 
     def loop(self):
         rate = rospy.Rate(50)
         while not rospy.is_shutdown():
-            if self.pose and self.base_waypoints:
+            if self.pose and self.base_lane:
                 # Get the closest waypoint
                 closest_wp = self.get_closest_waypoint_idx()
                 self.publish_waypoints(closest_wp)
-        rate.sleep()
+            rate.sleep()
 
     def get_closest_waypoint_idx(self):
         x = self.pose.pose.position.x
@@ -79,27 +82,53 @@ class WaypointUpdater(object):
         return closest_idx
 
     def publish_waypoints(self, closest_idx):
+        final_lane = self.generate_lane()
+        self.final_waypoints_pub.publish(final_lane)
+
+    def generate_lane(self):
         lane = Lane()
-        lane.header = self.base_waypoints.header
-        lane.waypoints = self.base_waypoints.waypoints[closest_idx:closest_idx + LOOKAHEAD_WPS]
-        self.final_waypoints_pub.publish(lane)
+
+        closest_idx = self.get_closest_waypoint_idx()
+        farthest_idx = closest_idx + LOOKAHEAD_WPS
+        base_waypoints = self.base_lane.waypoints[closest_idx:farthest_idx]
+
+        if (self.stopline_wp_idx == -1) or (self.stopline_wp_idx >= farthest_idx):
+            lane.waypoints = base_waypoints
+        else:
+            lane.waypoints = self.decelerate_waypoints(base_waypoints, closest_idx)
+
+        return lane
+
+    def decelerate_waypoints(self, waypoints, start_idx):
+        new_waypoints = []
+        for i, wp in enumerate(waypoints):
+            p = Waypoint()
+            p.pose = wp.pose
+            stop_idx = max(self.stopline_wp_idx - start_idx - 2, 0) # -2 to accomodate car front to be behind stop line
+            dist = self.distance(waypoints, i, stop_idx)
+            vel = math.sqrt(2 * MAX_DECEL * dist) # u^2 = v^2 - 2*a*d, v = 0, a < 0
+            if vel < 1:
+                vel = 0
+
+            p.twist.twist.linear.x = min(vel, self.get_waypoint_velocity(p))
+            new_waypoints.append(p)
+        return new_waypoints
+            
 
     def pose_cb(self, msg):
         # TODO: Implement
         self.pose = msg
-        pass
 
     def waypoints_cb(self, waypoints):
         # TODO: Implement
-        self.base_waypoints = waypoints
+        self.base_lane = waypoints
         if not self.waypoints_2d:
             self.waypoints_2d = [[wp.pose.pose.position.x, wp.pose.pose.position.y] for wp in waypoints.waypoints]
             self.waypoint_tree = KDTree(self.waypoints_2d)
-        pass
 
     def traffic_cb(self, msg):
         # TODO: Callback for /traffic_waypoint message. Implement
-        pass
+        self.stopline_wp_idx = msg.data
 
     def obstacle_cb(self, msg):
         # TODO: Callback for /obstacle_waypoint message. We will implement it later


### PR DESCRIPTION
Merge has following fix:
- Increasing lookahead waypoints back to 200
- Introducing stop decel waypoints (25) to start decelerating
- Maintaining minimum speed of 1 mph untill stopline is reached
- Adjusting stopline by -4 to keep car at safer distance
- Introducing max tl classification waypoints (200) to ignore classification for lights whose stop lines are beyond these points.
- Adding a dummy image classification in constructor of classifier, first classification loads the graphs and is often slower then following classification.
- Adding a config use_classifier to initialize and use classifier only if config is defined, else light.state is used, helpful to quickly debug other modules without classifier.